### PR TITLE
Added new value for ovirt_host_up metric for Host Maintenance status

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "0.9.1"
+const version string = "0.9.2"
 
 var (
 	showVersion     = flag.Bool("version", false, "Print version information.")


### PR DESCRIPTION
If host shoud be maintenanced or just installing we don't want alert for this state
My oVirt admins are tired to set silence's on certificate enrollments, librbd updates or another rutine (non actually `host is down`) tasks

Fixes #10